### PR TITLE
fix: correct the line indexing in extractEnumValues and extractModelProperties

### DIFF
--- a/src/services/summary.service.ts
+++ b/src/services/summary.service.ts
@@ -1,44 +1,44 @@
-import { IPrismaSummaryGenerator } from '../models/prisma.model';
+import { IPrismaSummaryGenerator } from "../models/prisma.model";
 
 export class PrismaSummaryGenerator implements IPrismaSummaryGenerator {
   generateSummary(text: string): string[] {
-    const lines = text.split('\n');
+    const lines = text.split("\n");
     return [
       ...this.generateModelSummary(lines),
-      ...this.generateEnumSummary(lines)
+      ...this.generateEnumSummary(lines),
     ];
   }
-  
+
   private generateModelSummary(lines: string[]): string[] {
-    const modelSummary: string[] = ['<h2>Models</h2><ul>'];
-    
+    const modelSummary: string[] = ["<h2>Models</h2><ul>"];
+
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      if (line.startsWith('model ')) {
-        const modelName = line.split(' ')[1];
+      if (line.startsWith("model ")) {
+        const modelName = line.split(" ")[1];
         modelSummary.push(this.createSummaryItem(modelName, i));
       }
     }
-    
-    modelSummary.push('</ul>');
+
+    modelSummary.push("</ul>");
     return modelSummary;
   }
-  
+
   private generateEnumSummary(lines: string[]): string[] {
-    const enumSummary: string[] = ['<h2>Enums</h2><ul>'];
-    
+    const enumSummary: string[] = ["<h2>Enums</h2><ul>"];
+
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      if (line.startsWith('enum ')) {
-        const enumName = line.split(' ')[1];
+      if (line.startsWith("enum ")) {
+        const enumName = line.split(" ")[1];
         enumSummary.push(this.createSummaryItem(enumName, i));
       }
     }
-    
-    enumSummary.push('</ul>');
+
+    enumSummary.push("</ul>");
     return enumSummary;
   }
-  
+
   private createSummaryItem(name: string, lineNumber: number): string {
     return `<li><a href="command:revealLine?lineNumber=${lineNumber}">${name}</a></li>`;
   }

--- a/src/views/tree.view.ts
+++ b/src/views/tree.view.ts
@@ -154,7 +154,9 @@ export class PrismaSummaryProvider
             title: "",
             arguments: [
               vscode.Uri.file(prismaFilePath),
-              { selection: new vscode.Range(prop.line, 0, prop.line, 0) },
+              {
+                selection: new vscode.Range(prop.line, 0, prop.line, 0),
+              },
             ],
           }
         )
@@ -180,7 +182,7 @@ export class PrismaSummaryProvider
 
     const properties: { name: string; type: string; line: number }[] = [];
 
-    let currentLine = modelStartLine + 1;
+    let currentLine = modelStartLine;
 
     for (const line of lines) {
       const trimmed = line.trim();
@@ -239,7 +241,7 @@ export class PrismaSummaryProvider
     );
     const values: { value: string; line: number }[] = [];
 
-    let currentLine = enumStartLine + 1;
+    let currentLine = enumStartLine;
 
     for (const line of lines) {
       const trimmed = line.trim();


### PR DESCRIPTION
# 🛠 Fix: Correct Line Indexing in extractEnumValues and extractModelProperties

##  What Changed?  
This update corrects the line indexing in `extractEnumValues` and `extractModelProperties`, ensuring that clicking on a model, enum, or property in the **Prisma Explorer** now correctly navigates to the exact line in `schema.prisma`.

##  Issue Fixed  
Previously, clicking on a Prisma model, enum, or property in the **VS Code Tree View** would open the **wrong line**, one line below the actual declaration.
